### PR TITLE
Fix exception on transmission abort with python3

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,12 @@ servefile changelog
 ===================
 
 
+Unreleased
+----------
+
+	* fixed bug where exception was shown on transmission abort with python3
+
+
 2020-10-30 v0.5.1
 -----------------
 

--- a/servefile/servefile.py
+++ b/servefile/servefile.py
@@ -714,7 +714,8 @@ class FilePutter(BaseHTTPServer.BaseHTTPRequestHandler):
 
 class ThreadedHTTPServer(SocketServer.ThreadingMixIn, BaseHTTPServer.HTTPServer):
 	def handle_error(self, request, client_address):
-		print("%s ABORTED transmission (Reason: %s)" % (client_address[0], sys.exc_value))
+		_, exc_value, _ = sys.exc_info()
+		print("%s ABORTED transmission (Reason: %s)" % (client_address[0], exc_value))
 
 
 def catchSSLErrors(BaseSSLClass):


### PR DESCRIPTION
With python3 sys.exc_value does no longer exist, but we can replace it
with sys.exc_info().