### PR TITLE
Fix broken pyopenssl and debian references

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ Unreleased
 ----------
 
 	* fixed bug where exception was shown on transmission abort with python3
+	* fixed wrong/outdated pyopenssl package names
 
 
 2020-10-30 v0.5.1

--- a/servefile.1
+++ b/servefile.1
@@ -28,8 +28,8 @@ In upload mode with \fB\-u\fR servefile creates a directory and saves all
 uploaded files into that directory. When uploading with curl or wget the
 filename is extracted from the path part of the url used for the upload.
 
-For SSL support python-openssl (pyssl) needs to be installed. If no key and
-cert is given, servefile will generate a key pair for you and display its
+For SSL support pyopenssl (python3-openssl) needs to be installed. If no key
+and cert is given, servefile will generate a key pair for you and display its
 fingerprint.
 
 In \fB--tar\fR mode the given file or directory will be packed on (each)

--- a/servefile/servefile.py
+++ b/servefile/servefile.py
@@ -858,7 +858,7 @@ class ServeFile():
 		return None
 
 	def setSSLKeys(self, cert, key):
-		""" Set SSL cert/key. Can be either path to file or pyssl X509/PKey object. """
+		""" Set SSL cert/key. Can be either path to file or pyopenssl X509/PKey object. """
 		self.cert = cert
 		self.key = key
 
@@ -1167,7 +1167,7 @@ def main():
 			sys.exit(1)
 
 	if args.ssl and not HAVE_SSL:
-		print("Error: SSL is not available, please install pyssl (python-openssl).")
+		print("Error: SSL is not available, please install pyopenssl (python3-openssl).")
 		sys.exit(1)
 
 	if args.cert and not args.key:


### PR DESCRIPTION
servefile used to hint to install pyssl when ssl support was missing.
This is utterly wrong, because the package is named pyopenssl - as
stated in setup.py. Installing pyssl will not only not lead to ssl
support, but also install a random package that we do not want.

Also, since python2 has genereally been deprecated (though it is still
support by servefile for now) we hint for the python3 package of
pyopenssl instead of the python2 version. I thought about building a
version detection and print the right package, depending if the user is
using python2 or 3, but I deemed it not being worth it.

Fixes #7 (GitHub)