### PR TITLE
Allow ports for tests to be specified via env

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ Unreleased
 
 	* fixed bug where exception was shown on transmission abort with python3
 	* fixed wrong/outdated pyopenssl package names
+	* tests are now using a free non-default port to avoid clashes; if
+	  wished the ports can be set from outside by specifying the
+	  environment variables SERVEFILE_DEFAULT_PORT and
+	  SERVEFILE_SECONDARY_PORT
 
 
 2020-10-30 v0.5.1


### PR DESCRIPTION
SERVEFILE_DEFAULT_PORT and SERVEFILE_SECONDARY_PORT can be used to
specify ports used in the servefile tests. This can be useful if the
default port 8080 and the secondary port 8081 (for the -p test) are
already in use. To allow automatic choosing of a free port 0 can be
specified to tell the test code to automatically select a free port.