### PR TITLE
Fix PUT uploads

### DIFF
--- a/servefile/servefile.py
+++ b/servefile/servefile.py
@@ -635,7 +635,7 @@ class FilePutter(BaseHTTPServer.BaseHTTPRequestHandler):
 		http://host:8080/testfile will cause the file to be named testfile. If
 		no filename is given, a random name will be generated.
 
-		Files can be uploaded with e.g. curl -X POST -d @file <url> .
+		Files can be uploaded with e.g. curl -T file <url> .
 		"""
 		length = self.getContentLength()
 		if length < 0:
@@ -652,11 +652,11 @@ class FilePutter(BaseHTTPServer.BaseHTTPRequestHandler):
 			return
 
 		# Sometimes clients want to be told to continue with their transfer
-		if self.headers.getheader("Expect") == "100-continue":
+		if self.headers.get("Expect") == "100-continue":
 			self.send_response(100)
 			self.end_headers()
 
-		target = open(cleanFileName, "w")
+		target = open(cleanFileName, "wb")
 		bytesLeft = int(self.headers['Content-Length'])
 		while bytesLeft > 0:
 			bytesToRead = min(self.blockSize, bytesLeft)

--- a/tests/test_servefile.py
+++ b/tests/test_servefile.py
@@ -291,6 +291,13 @@ def test_upload(run_servefile, tmp_path):
     with open(str(uploaddir / 'haiku.txt(1)')) as f:
         assert f.read() == data
 
+    # upload file using PUT
+    r = make_request("/haiku.txt", method='put', data=data)
+    assert r.status_code == 201
+    assert 'OK!' in r.text
+    with open(str(uploaddir / 'haiku.txt(2)')) as f:
+        assert f.read() == data
+
 
 def test_upload_size_limit(run_servefile, tmp_path):
     uploaddir = tmp_path / 'upload'


### PR DESCRIPTION
PUT uploads appeared to be broken on python 3.9

Added tests to cover PUT uploads. And fixed the documentation snippet to point to `curl -T` file upload helper 

@sebageek Thanks for awesome tool!

BTW My testing showed PUT uploads to be as fast as my SSD allowed, while POST took 8x longer. Probably because of https://bytes.com/topic/python/answers/38188-cgi-fieldstorage-slow